### PR TITLE
Upgraded dependency version of Confluence Publisher to 0.27.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ plugins {
 }
 
 group = 'ch.nomisp'
-version = '0.5.0'
+version = '0.6.0'
 
 repositories {
     // Use Maven Central for resolving dependencies.

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ asciiDocGitPublishPluginVersion=3.0.0
 asciidoctorjDiagramVersion=2.2.8
 credentialsPluginVersion=3.0
 pluginPublishPluginVersion=0.16.0
-confluencePublisherPluginVersion=0.4.0
+confluencePublisherPluginVersion=0.5.0
 
 # Dependency versions
-asciidocConfluencePublisherVersion=0.22.0
+asciidocConfluencePublisherVersion=0.27.0

--- a/src/docs/asciidoc/index/release-notes.adoc
+++ b/src/docs/asciidoc/index/release-notes.adoc
@@ -8,6 +8,20 @@
 :sectlinks:
 :sectnums:
 
+== Release 0.6.0
+
+=== New and Noteworthy/Highlights/What's New
+Upgraded dependency version of https://github.com/confluence-publisher/confluence-publisher[Confluence Publisher] to https://github.com/confluence-publisher/confluence-publisher/releases/tag/0.27.0[0.27.0].
+
+=== Additional Features and Changes/Minor Features and Changes/Other Features and Changes
+
+=== Changelog
+* Upgraded dependency version of Confluence Publisher to 0.27.0.
+
+=== Deprecations
+
+=== Known problems
+
 == Release 0.5.0
 
 === New and Noteworthy/Highlights/What's New


### PR DESCRIPTION
Fixes problem with callout rendering, see: https://github.com/confluence-publisher/confluence-publisher/pull/454

Tested locally